### PR TITLE
`transferFrom`-> `safeTransferFrom` in Hyperstaker

### DIFF
--- a/src/Hyperstaker.sol
+++ b/src/Hyperstaker.sol
@@ -95,14 +95,14 @@ contract Hyperstaker is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgra
 
         stakes[_hypercertId].stakingStartTime = block.timestamp;
         emit Staked(_hypercertId);
-        hypercertMinter.transferFrom(msg.sender, address(this), _hypercertId, units);
+        hypercertMinter.safeTransferFrom(msg.sender, address(this), _hypercertId, units, "");
     }
 
     function unstake(uint256 _hypercertId) external whenNotPaused {
         uint256 units = hypercertMinter.unitsOf(_hypercertId);
         delete stakes[_hypercertId].stakingStartTime;
         emit Unstaked(_hypercertId);
-        hypercertMinter.transferFrom(address(this), msg.sender, _hypercertId, units);
+        hypercertMinter.safeTransferFrom(address(this), msg.sender, _hypercertId, units, "");
     }
 
     function claimReward(uint256 _hypercertId) external whenNotPaused {
@@ -114,7 +114,9 @@ contract Hyperstaker is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgra
         stakes[_hypercertId].isClaimed = true;
         emit RewardClaimed(msg.sender, reward);
 
-        hypercertMinter.transferFrom(address(this), msg.sender, _hypercertId, hypercertMinter.unitsOf(_hypercertId));
+        hypercertMinter.safeTransferFrom(
+            address(this), msg.sender, _hypercertId, hypercertMinter.unitsOf(_hypercertId), ""
+        );
 
         if (rewardToken != address(0)) {
             require(IERC20(rewardToken).transfer(msg.sender, reward), RewardTransferFailed());

--- a/src/interfaces/IHypercertToken.sol
+++ b/src/interfaces/IHypercertToken.sol
@@ -17,8 +17,7 @@ interface IHypercertToken {
     function splitFraction(address to, uint256 tokenID, uint256[] memory _values) external;
     function unitsOf(uint256 tokenID) external view returns (uint256 units);
     function ownerOf(uint256 tokenID) external view returns (address owner);
-    function transferFrom(address from, address to, uint256 tokenId, uint256 units) external;
-    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes memory data) external;
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes memory data) external;
     function burnFraction(address from, uint256 tokenId) external;
     function setApprovalForAll(address operator, bool approved) external;
     function name() external view returns (string memory);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced token transfer operations in staking, unstaking, and reward claiming to use a safer transfer method, ensuring improved error handling.

- **Chores**
  - Streamlined the token transfer interface by removing outdated functionality and simplifying method parameters for a clearer design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->