### PR TITLE
remove `isClaimed` and delete stake info on `claimReward`

### DIFF
--- a/test/Hyperstaker.t.sol
+++ b/test/Hyperstaker.t.sol
@@ -116,7 +116,6 @@ contract HyperstakerTest is Test {
 
         Hyperstaker.Stake memory stakeInfo = hyperstaker.getStake(stakerHypercertId);
         assertEq(stakeInfo.staker, staker);
-        assertEq(stakeInfo.isClaimed, false);
         assertEq(stakeInfo.stakingStartTime, block.timestamp);
         assertEq(hypercertMinter.unitsOf(stakerHypercertId), stakeAmount);
         assertEq(hypercertMinter.ownerOf(stakerHypercertId), address(hyperstaker));
@@ -232,7 +231,7 @@ contract HyperstakerTest is Test {
         hyperstaker.claimReward(stakerHypercertId);
         vm.stopPrank();
         Hyperstaker.Stake memory stakeInfo = hyperstaker.getStake(stakerHypercertId);
-        assertEq(stakeInfo.isClaimed, true);
+        assertEq(stakeInfo.stakingStartTime, 0);
         assertEq(hypercertMinter.ownerOf(stakerHypercertId), staker);
     }
 
@@ -255,10 +254,13 @@ contract HyperstakerTest is Test {
     }
 
     function test_RevertWhen_ClaimRewardAlreadyClaimed() public {
-        test_ClaimReward_Eth();
-        vm.prank(staker);
-        vm.expectRevert(AlreadyClaimed.selector);
+        _setupStake();
+        _setupRewardEth();
+        vm.startPrank(staker);
         hyperstaker.claimReward(stakerHypercertId);
+        vm.expectRevert(NotStaked.selector);
+        hyperstaker.claimReward(stakerHypercertId);
+        vm.stopPrank();
     }
 
     function test_RevertWhen_ClaimRewardRoundNotSet() public {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the reward claiming process by removing a redundant flag and simplifying validations. Rewards are now claimed by verifying the stake's existence, which improves the clarity of state transitions.
  
- **Tests**
	- Updated tests to align with the new reward claim logic. The tests now verify stake timing instead of a claimed flag, ensuring consistency with the revised process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->