### PR TITLE
feat: add NotAllowlisted error

### DIFF
--- a/src/Hyperfund.sol
+++ b/src/Hyperfund.sol
@@ -49,6 +49,7 @@ contract Hyperfund is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgrade
     error NotFractionOfThisHypercert(uint256 rightHypercertId);
     error Unauthorized();
     error ArrayLengthsMismatch();
+    error NotAllowlisted();
 
     constructor() {
         _disableInitializers();
@@ -152,6 +153,7 @@ contract Hyperfund is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgrade
     /// @param _fractionId id of the hypercert fraction
     /// @param _token address of the token to redeem, must be allowlisted. address(0) for native token
     function redeem(uint256 _fractionId, address _token) external whenNotPaused {
+        require(nonfinancialContributions[msg.sender] != 0, NotAllowlisted());
         require(hypercertMinter.ownerOf(_fractionId) == msg.sender, Unauthorized());
         require(_isFraction(_fractionId), NotFractionOfThisHypercert(hypercertTypeId));
         uint256 units = hypercertMinter.unitsOf(_fractionId);
@@ -163,7 +165,7 @@ contract Hyperfund is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgrade
             require(IERC20(_token).transfer(msg.sender, tokenAmount), TransferFailed());
         }
         hypercertMinter.burnFraction(msg.sender, _fractionId); // sets the units of the fraction to 0
-        nonfinancialContributions[msg.sender] -= units; // will underflow if the sender is not allowlisted
+        nonfinancialContributions[msg.sender] -= units;
         emit FractionRedeemed(_fractionId, _token, tokenAmount);
     }
 

--- a/test/Hyperfund.t.sol
+++ b/test/Hyperfund.t.sol
@@ -342,7 +342,7 @@ contract HyperfundTest is Test {
         fundingToken.approve(address(hyperfund), amount);
         hyperfund.fund(address(fundingToken), amount);
         hypercertMinter.setApprovalForAll(address(hyperfund), true);
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(Hyperfund.NotAllowlisted.selector);
         hyperfund.redeem(fractionHypercertId + 1, address(fundingToken));
         vm.stopPrank();
     }
@@ -360,7 +360,7 @@ contract HyperfundTest is Test {
         hyperfund.fund(address(fundingToken), amount);
         hypercertMinter.setApprovalForAll(address(hyperfund), true);
         hyperfund.redeem(fractionHypercertId + 1, address(fundingToken));
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(Hyperfund.NotAllowlisted.selector);
         hyperfund.redeem(fractionHypercertId + 2, address(fundingToken));
         vm.stopPrank();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom error message when attempting to redeem without being allowlisted, providing clearer feedback to users.

- **Bug Fixes**
  - Improved error handling during redemption to prevent underflow and ensure only allowlisted contributors can redeem fractions.

- **Tests**
  - Updated tests to check for the new custom error when redemption is attempted by non-allowlisted users or beyond their allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->