### PR TITLE
feat: add default admin, pauser and upgrader roles on initialization

### DIFF
--- a/src/Hyperfund.sol
+++ b/src/Hyperfund.sol
@@ -58,14 +58,26 @@ contract Hyperfund is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgrade
     /// by calling hypercertMinter.setApprovalForAll(address(proxy), true)
     /// @param _hypercertMinter The address of the hypercert minter contract
     /// @param _hypercertTypeId The id of the hypercert type
-    /// @param _manager The address that will have the MANAGER_ROLE in the new Hyperfund, pausers and upgraders can be added later
-    function initialize(address _hypercertMinter, uint256 _hypercertTypeId, address _manager) public initializer {
+    /// @param _admin The address that will have the DEFAULT_ADMIN_ROLE
+    /// @param _manager The address that will have the MANAGER_ROLE
+    /// @param _pauser The address that will have the PAUSER_ROLE
+    /// @param _upgrader The address that will have the UPGRADER_ROLE
+    function initialize(
+        address _hypercertMinter,
+        uint256 _hypercertTypeId,
+        address _admin,
+        address _manager,
+        address _pauser,
+        address _upgrader
+    ) public initializer {
         __AccessControl_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
 
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
         _grantRole(MANAGER_ROLE, _manager);
+        _grantRole(PAUSER_ROLE, _pauser);
+        _grantRole(UPGRADER_ROLE, _upgrader);
 
         hypercertMinter = IHypercertToken(_hypercertMinter);
         hypercertTypeId = _hypercertTypeId;

--- a/src/Hyperstaker.sol
+++ b/src/Hyperstaker.sol
@@ -63,14 +63,26 @@ contract Hyperstaker is AccessControlUpgradeable, PausableUpgradeable, UUPSUpgra
     /// by calling hypercertMinter.setApprovalForAll(address(proxy), true)
     /// @param _hypercertMinter The address of the hypercert minter contract
     /// @param _hypercertTypeId The id of the hypercert type
+    /// @param _admin The address that will have the DEFAULT_ADMIN_ROLE
     /// @param _manager The address that will have the MANAGER_ROLE
-    function initialize(address _hypercertMinter, uint256 _hypercertTypeId, address _manager) public initializer {
+    /// @param _pauser The address that will have the PAUSER_ROLE
+    /// @param _upgrader The address that will have the UPGRADER_ROLE
+    function initialize(
+        address _hypercertMinter,
+        uint256 _hypercertTypeId,
+        address _admin,
+        address _manager,
+        address _pauser,
+        address _upgrader
+    ) public initializer {
         __AccessControl_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
 
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
         _grantRole(MANAGER_ROLE, _manager);
+        _grantRole(PAUSER_ROLE, _pauser);
+        _grantRole(UPGRADER_ROLE, _upgrader);
 
         hypercertMinter = IHypercertToken(_hypercertMinter);
         hypercertTypeId = _hypercertTypeId;

--- a/test/Hyperfund.t.sol
+++ b/test/Hyperfund.t.sol
@@ -40,8 +40,9 @@ contract HyperfundTest is Test {
         assertEq(hypercertMinter.ownerOf(fractionHypercertId), address(this));
         fundingToken = new MockERC20("Funding", "FUND");
         implementation = new Hyperfund();
-        bytes memory initData =
-            abi.encodeWithSelector(Hyperfund.initialize.selector, address(hypercertMinter), hypercertTypeId, manager);
+        bytes memory initData = abi.encodeWithSelector(
+            Hyperfund.initialize.selector, address(hypercertMinter), hypercertTypeId, manager, manager, manager, manager
+        );
 
         proxy = new ERC1967Proxy(address(implementation), initData);
         hypercertMinter.setApprovalForAll(address(proxy), true);

--- a/test/HyperfundFactory.t.sol
+++ b/test/HyperfundFactory.t.sol
@@ -101,9 +101,9 @@ contract HyperfundFactoryTest is Test {
         vm.expectEmit(false, true, false, true);
         // We can't know the hyperfund address beforehand, but we can emit a dummy event
         // with the other parameters we expect
-        emit HyperfundFactory.HyperfundCreated(address(0), manager, hypercertId);
+        emit HyperfundFactory.HyperfundCreated(address(0), hypercertId, manager, manager, manager, manager);
 
-        address hyperfundAddress = hyperfundFactory.createHyperfund(hypercertId, manager);
+        address hyperfundAddress = hyperfundFactory.createHyperfund(hypercertId, manager, manager, manager, manager);
 
         bool createdHyperfund = hyperfundFactory.hyperfunds(hypercertId);
         assertTrue(createdHyperfund != false, "Hyperfund should be created and mapped correctly");
@@ -115,9 +115,9 @@ contract HyperfundFactoryTest is Test {
         vm.expectEmit(false, true, false, true);
         // We can't know the hyperfund address beforehand, but we can emit a dummy event
         // with the other parameters we expect
-        emit HyperfundFactory.HyperstakerCreated(address(0), manager, hypercertId);
+        emit HyperfundFactory.HyperstakerCreated(address(0), hypercertId, manager, manager, manager, manager);
 
-        address hyperstakerAddress = hyperfundFactory.createHyperstaker(hypercertId, manager);
+        address hyperstakerAddress = hyperfundFactory.createHyperstaker(hypercertId, manager, manager, manager, manager);
 
         bool createdHyperstaker = hyperfundFactory.hyperstakers(hypercertId);
         assertTrue(createdHyperstaker != false, "Hyperstaker should be created and mapped correctly");
@@ -125,27 +125,27 @@ contract HyperfundFactoryTest is Test {
     }
 
     function test_RevertWhen_RedeployingHyperfundWithSameHypercertId() public {
-        hyperfundFactory.createHyperfund(hypercertId, manager);
+        hyperfundFactory.createHyperfund(hypercertId, manager, manager, manager, manager);
 
         vm.expectRevert(HyperfundFactory.AlreadyDeployed.selector);
-        hyperfundFactory.createHyperfund(hypercertId, manager);
+        hyperfundFactory.createHyperfund(hypercertId, manager, manager, manager, manager);
     }
 
     function test_RevertWhen_RedeployingHyperStakerWithSameHypercertId() public {
-        hyperfundFactory.createHyperstaker(hypercertId, manager);
+        hyperfundFactory.createHyperstaker(hypercertId, manager, manager, manager, manager);
 
         vm.expectRevert(HyperfundFactory.AlreadyDeployed.selector);
-        hyperfundFactory.createHyperstaker(hypercertId, manager);
+        hyperfundFactory.createHyperstaker(hypercertId, manager, manager, manager, manager);
     }
 
     function test_RevertWhen_CreateHyperfundZeroManager() public {
         vm.expectRevert(HyperfundFactory.InvalidAddress.selector);
-        hyperfundFactory.createHyperfund(hypercertId, address(0));
+        hyperfundFactory.createHyperfund(hypercertId, address(0), address(0), address(0), address(0));
     }
 
     function test_RevertWhen_CreateHyperstakerZeroManager() public {
         vm.expectRevert(HyperfundFactory.InvalidAddress.selector);
-        hyperfundFactory.createHyperstaker(hypercertId, address(0));
+        hyperfundFactory.createHyperstaker(hypercertId, address(0), address(0), address(0), address(0));
     }
 
     function test_RevertWhen_FailedHyperfundDeployment() public {
@@ -170,7 +170,7 @@ contract HyperfundFactoryTest is Test {
         HyperfundFactory factory = HyperfundFactory(address(proxy));
 
         vm.expectRevert();
-        factory.createHyperfund(hypercertId, manager);
+        factory.createHyperfund(hypercertId, manager, manager, manager, manager);
     }
 
     function test_RevertWhen_FailedHyperstakerDeployment() public {
@@ -195,23 +195,24 @@ contract HyperfundFactoryTest is Test {
         HyperfundFactory factory = HyperfundFactory(address(proxy));
 
         vm.expectRevert();
-        factory.createHyperstaker(hypercertId, manager);
+        factory.createHyperstaker(hypercertId, manager, manager, manager, manager);
     }
 
     function test_RevertWhen_HyperfundCreatorNotOwnerOfHypercert() public {
         vm.prank(makeAddr("user2"));
         vm.expectRevert(HyperfundFactory.NotOwnerOfHypercert.selector);
-        hyperfundFactory.createHyperfund(hypercertId, manager);
+        hyperfundFactory.createHyperfund(hypercertId, manager, manager, manager, manager);
     }
 
     function test_RevertWhen_HyperstakerCreatorNotOwnerOfHypercert() public {
         vm.prank(makeAddr("user2"));
         vm.expectRevert(HyperfundFactory.NotOwnerOfHypercert.selector);
-        hyperfundFactory.createHyperstaker(hypercertId, manager);
+        hyperfundFactory.createHyperstaker(hypercertId, manager, manager, manager, manager);
     }
 
     function test_CreateProject() public {
-        (address hyperfundAddress, address hyperstakerAddress) = hyperfundFactory.createProject(hypercertId, manager);
+        (address hyperfundAddress, address hyperstakerAddress) =
+            hyperfundFactory.createProject(hypercertId, manager, manager, manager, manager);
         assertTrue(hyperfundFactory.hyperfunds(hypercertId));
         assertTrue(hyperfundFactory.hyperstakers(hypercertId));
         assertEq(Hyperfund(hyperfundAddress).hypercertTypeId(), hypercertId);

--- a/test/Hyperstaker.t.sol
+++ b/test/Hyperstaker.t.sol
@@ -42,8 +42,15 @@ contract HyperstakerTest is Test {
         rewardToken = new MockERC20("Reward", "RWD");
 
         implementation = new Hyperstaker();
-        bytes memory initData =
-            abi.encodeWithSelector(Hyperstaker.initialize.selector, address(hypercertMinter), hypercertTypeId, manager);
+        bytes memory initData = abi.encodeWithSelector(
+            Hyperstaker.initialize.selector,
+            address(hypercertMinter),
+            hypercertTypeId,
+            manager,
+            manager,
+            manager,
+            manager
+        );
 
         proxy = new ERC1967Proxy(address(implementation), initData);
         hypercertMinter.setApprovalForAll(address(proxy), true);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -38,8 +38,9 @@ contract IntegrationTest is Test {
         hypercertId = hypercertTypeId + 1;
         fundingToken = new MockERC20("Funding", "FUND");
         implementation = new Hyperfund();
-        bytes memory initData =
-            abi.encodeWithSelector(Hyperfund.initialize.selector, address(hypercertMinter), hypercertTypeId, manager);
+        bytes memory initData = abi.encodeWithSelector(
+            Hyperfund.initialize.selector, address(hypercertMinter), hypercertTypeId, manager, manager, manager, manager
+        );
 
         proxy = new ERC1967Proxy(address(implementation), initData);
         hypercertMinter.setApprovalForAll(address(proxy), true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced role management by allowing separate assignment of admin, manager, pauser, and upgrader roles when creating or initializing Hyperfund and Hyperstaker contracts.
  - Updated event payloads to include all assigned role addresses for greater transparency.

- **Tests**
  - Updated test cases to reflect the new initialization parameters and event structures for role assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->