### PR TITLE
fix: use makeAddr instead of vm.addr which creates a contract

### DIFF
--- a/test/Hyperfund.t.sol
+++ b/test/Hyperfund.t.sol
@@ -17,9 +17,9 @@ contract HyperfundTest is Test {
     MockERC20 public fundingToken;
     uint256 public hypercertTypeId;
     uint256 public fractionHypercertId;
-    address public manager = vm.addr(1);
-    address public contributor = vm.addr(2);
-    address public contributor2 = vm.addr(3);
+    address public manager = makeAddr("manager");
+    address public contributor = makeAddr("contributor");
+    address public contributor2 = makeAddr("contributor2");
     uint256 public totalUnits = 100000000;
     uint256 public amount = 10000;
     uint256 public amount2 = 20000;

--- a/test/Hyperstaker.t.sol
+++ b/test/Hyperstaker.t.sol
@@ -17,9 +17,9 @@ contract HyperstakerTest is Test {
     uint256 public hypercertTypeId;
     uint256 public fractionHypercertId;
     uint256 public stakerHypercertId;
-    address public manager = vm.addr(1);
-    address public staker = vm.addr(2);
-    address public staker2 = vm.addr(3);
+    address public manager = makeAddr("manager");
+    address public staker = makeAddr("staker");
+    address public staker2 = makeAddr("staker2");
     uint256 public totalUnits = 100000000;
     uint256 public stakeAmount = 10000;
     uint256 public rewardAmount = 10 ether;

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -17,10 +17,10 @@ contract IntegrationTest is Test {
     MockERC20 public fundingToken;
     uint256 public hypercertTypeId;
     uint256 public hypercertId;
-    address public manager = vm.addr(1);
-    address public contributor = vm.addr(2);
-    address public contributor2 = vm.addr(3);
-    address public contributor3 = vm.addr(4);
+    address public manager = makeAddr("manager");
+    address public contributor = makeAddr("contributor");
+    address public contributor2 = makeAddr("contributor2");
+    address public contributor3 = makeAddr("contributor3");
     uint256 public totalUnits = 100000000;
 
     bytes32 public MANAGER_ROLE = keccak256("MANAGER_ROLE");


### PR DESCRIPTION
this changed in foundry and made the test fail on sending to a contract that doesn't implement onERC1155Recieved